### PR TITLE
Scintilla: only unlock clipboard if lock succeeded

### DIFF
--- a/src/scintilla/haiku/ScintillaHaiku.cxx
+++ b/src/scintilla/haiku/ScintillaHaiku.cxx
@@ -571,8 +571,8 @@ void ScintillaHaiku::CopyToClipboard(const SelectionText& selectedText) {
 			}
 			be_clipboard->Commit();
 		}
+		be_clipboard->Unlock();
 	}
-	be_clipboard->Unlock();
 }
 
 bool ScintillaHaiku::FineTickerRunning(TickReason reason) {


### PR DESCRIPTION
ScintillaHaiku::CopyToClipboard unlocked clipboard also if locking didn't succeed. Fixed.