### PR TITLE
GenioWindow: use a BMessageRunner to update the status bar trailing text every second.

### DIFF
--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -18,6 +18,7 @@
 #include <Catalog.h>
 #include <IconUtils.h>
 #include <LayoutBuilder.h>
+#include <MessageRunner.h>
 #include <NodeInfo.h>
 #include <NodeMonitor.h>
 #include <Path.h>
@@ -67,6 +68,7 @@ static float kOutputWeight  = 0.4f;
 
 BRect dirtyFrameHack;
 
+const uint32 kRunnerMessage('RnMs');
 
 class ProjectRefFilter : public BRefFilter {
 
@@ -200,6 +202,7 @@ GenioWindow::GenioWindow(BRect frame)
 	, fConsoleIOThread(nullptr)
 	, fBuildLogView(nullptr)
 	, fConsoleIOView(nullptr)
+	, fMessageRunner(nullptr)
 {
 	// Settings file check.
 	BPath path;
@@ -274,6 +277,8 @@ GenioWindow::GenioWindow(BRect frame)
 			}
 		}
 	}
+	
+	fMessageRunner = new BMessageRunner(this, new BMessage(kRunnerMessage), 1000000UL, -1);
 }
 
 GenioWindow::~GenioWindow()
@@ -283,6 +288,7 @@ GenioWindow::~GenioWindow()
 	delete fOpenPanel;
 	delete fSavePanel;
 	delete fOpenProjectFolderPanel;
+	delete fMessageRunner;
 }
 
 void
@@ -1171,6 +1177,9 @@ GenioWindow::MessageReceived(BMessage* message)
 			}
 			break;
 		}
+		case kRunnerMessage:
+			_UpdateStatusBarTrailing(fTabManager->SelectedTabIndex());
+			break;
 		default:			
 			BWindow::MessageReceived(message);
 			break;

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -624,7 +624,6 @@ GenioWindow::MessageReceived(BMessage* message)
 			if (editor) {
 				editor->SetReadOnly();
 				fFileUnlockedButton->SetEnabled(!editor->IsReadOnly());
-				_UpdateStatusBarTrailing(fTabManager->SelectedTabIndex());
 			}
 			break;
 		}
@@ -684,7 +683,6 @@ GenioWindow::MessageReceived(BMessage* message)
 			Editor* editor = fTabManager->SelectedEditor();
 			if (editor) {
 				editor->SetEndOfLine(SC_EOL_LF);
-				_UpdateStatusBarTrailing(fTabManager->SelectedTabIndex());
 			}
 			break;
 		}
@@ -692,7 +690,6 @@ GenioWindow::MessageReceived(BMessage* message)
 			Editor* editor = fTabManager->SelectedEditor();
 			if (editor) {
 				editor->SetEndOfLine(SC_EOL_CRLF);
-				_UpdateStatusBarTrailing(fTabManager->SelectedTabIndex());
 			}
 			break;
 		}
@@ -700,7 +697,6 @@ GenioWindow::MessageReceived(BMessage* message)
 			Editor* editor = fTabManager->SelectedEditor();
 			if (editor) {
 				editor->SetEndOfLine(SC_EOL_CR);
-				_UpdateStatusBarTrailing(fTabManager->SelectedTabIndex());
 			}
 			break;
 		}
@@ -1095,7 +1091,6 @@ GenioWindow::MessageReceived(BMessage* message)
 			Editor* editor = fTabManager->SelectedEditor();
 			if (editor)  {
 				editor->OverwriteToggle();
-				_UpdateStatusBarTrailing(fTabManager->SelectedTabIndex());
 			}
 			break;
 		}
@@ -1148,7 +1143,6 @@ GenioWindow::MessageReceived(BMessage* message)
 
 				editor->PretendPositionChanged();
 				_UpdateTabChange(index, "TABMANAGER_TAB_SELECTED");
-				_UpdateStatusBarTrailing(index);
 			}
 			break;
 		}

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -1178,7 +1178,8 @@ GenioWindow::MessageReceived(BMessage* message)
 			break;
 		}
 		case kRunnerMessage:
-			_UpdateStatusBarTrailing(fTabManager->SelectedTabIndex());
+			if (fTabManager->SelectedEditor() != NULL)
+				_UpdateStatusBarTrailing(fTabManager->SelectedTabIndex());
 			break;
 		default:			
 			BWindow::MessageReceived(message);

--- a/src/ui/GenioWindow.h
+++ b/src/ui/GenioWindow.h
@@ -274,6 +274,7 @@ private:
 			ConsoleIOView*		fBuildLogView;
 			ConsoleIOView*		fConsoleIOView;
 
+			BMessageRunner*		fMessageRunner;
 };
 
 #endif //GenioWINDOW_H


### PR DESCRIPTION
Use a BMessageRunner to update the status bar trailing text every second.
This fixes INS status in the statusbar when hitting the insert key (#45).

Now we could remove the other _UpdateStatusBarTrailing() calls, since this will update the trailing text ever second.