### PR TITLE
Arrow keys to change SignatureHelp

### DIFF
--- a/src/ui/Editor.cpp
+++ b/src/ui/Editor.cpp
@@ -726,6 +726,18 @@ Editor::NotificationReceived(SCNotification* notification)
 	}
 }
 
+void
+Editor::NextSignatureHelp(int direction)
+{
+	fFileWrapper->UpdateCallTip(direction);
+}
+
+bool
+Editor::IsSignatureHelpVisible()
+{
+	return SendMessage(SCI_CALLTIPACTIVE, 0, 0);
+}
+
 void				
 Editor::_UpdateSavePoint(bool modified)
 {

--- a/src/ui/Editor.cpp
+++ b/src/ui/Editor.cpp
@@ -726,16 +726,29 @@ Editor::NotificationReceived(SCNotification* notification)
 	}
 }
 
-void
-Editor::NextSignatureHelp(int direction)
-{
-	fFileWrapper->UpdateCallTip(direction);
+filter_result
+Editor::BeforeKeyDown(BMessage* message) {
+
+	int8 key = message->GetInt8("byte", 0);
+	switch (key) {
+		case B_UP_ARROW:
+		case B_DOWN_ARROW:
+			return OnArrowKey(key);
+		break;
+		default:
+		break;
+	};
+
+  return B_DISPATCH_MESSAGE;
 }
 
-bool
-Editor::IsSignatureHelpVisible()
-{
-	return SendMessage(SCI_CALLTIPACTIVE, 0, 0);
+filter_result		
+Editor::OnArrowKey(int8 key) {
+	if (SendMessage(SCI_CALLTIPACTIVE, 0, 0)) {
+		fFileWrapper->UpdateCallTip(key == B_UP_ARROW ? 1 : 2);
+		return B_SKIP_MESSAGE;
+	}
+	return B_DISPATCH_MESSAGE;
 }
 
 void				

--- a/src/ui/Editor.h
+++ b/src/ui/Editor.h
@@ -168,6 +168,9 @@ public:
 			
 			void				SetProblems(const BMessage* diagnostics);
 			void				GetProblems(BMessage* diagnostics);
+			
+			void				NextSignatureHelp(int direction);
+			bool				IsSignatureHelpVisible();
 
 private:
 			void				UpdateStatusBar();

--- a/src/ui/Editor.h
+++ b/src/ui/Editor.h
@@ -12,6 +12,7 @@
 #include <String.h>
 #include <string>
 #include <Locker.h>
+#include <MessageFilter.h>
 
 class FileWrapper;
 class ProjectFolder;
@@ -169,8 +170,8 @@ public:
 			void				SetProblems(const BMessage* diagnostics);
 			void				GetProblems(BMessage* diagnostics);
 			
-			void				NextSignatureHelp(int direction);
-			bool				IsSignatureHelpVisible();
+			filter_result		BeforeKeyDown(BMessage*);
+			filter_result		OnArrowKey(int8 ch);
 
 private:
 			void				UpdateStatusBar();

--- a/src/ui/EditorKeyDownMessageFilter.h
+++ b/src/ui/EditorKeyDownMessageFilter.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023, Andrea Anzani <andrea.anzani@gmail.com>
+ * All rights reserved. Distributed under the terms of the MIT license.
+ */
+#ifndef EditorKeyDownMessageFilter_H
+#define EditorKeyDownMessageFilter_H
+
+
+#include <SupportDefs.h>
+#include <MessageFilter.h>
+#include <View.h>
+
+// This filter is used to intercept key_down messages before they reach the Scintilla view.
+// This is needed because we can't override the KeyDown message of the scintilla view as it's 'hidden'
+// behind a BScrollView (see BScintillaView)
+
+class EditorKeyDownMessageFilter : public BMessageFilter {
+public:
+	EditorKeyDownMessageFilter():BMessageFilter(B_KEY_DOWN){};
+	filter_result		Filter(BMessage* message, BHandler** _target) {
+		if (_target && *_target) {
+			BView* scintillaView = dynamic_cast<BView*>(*_target);
+			if (scintillaView) {
+				Editor* editor = dynamic_cast<Editor*>(scintillaView->Parent());
+				if (editor) {
+					return editor->BeforeKeyDown(message);
+				}
+			}
+		}
+		return B_DISPATCH_MESSAGE;
+	}
+};
+
+
+#endif // EditorKeyDownMessageFilter_H

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -42,6 +42,7 @@
 #include "TPreferences.h"
 #include "TextUtils.h"
 #include "Utils.h"
+#include "EditorKeyDownMessageFilter.h"
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "GenioWindow"
@@ -215,6 +216,7 @@ GenioWindow::GenioWindow(BRect frame)
 	AddCommonFilter(new KeyDownMessageFilter(MSG_FILE_NEXT_SELECTED, B_RIGHT_ARROW, B_OPTION_KEY));
 	AddCommonFilter(new KeyDownMessageFilter(MSG_ESCAPE_KEY,   B_ESCAPE));
 	AddCommonFilter(new KeyDownMessageFilter(MSG_FIND_INVOKED, B_ENTER, 0, B_DISPATCH_MESSAGE));
+	AddCommonFilter(new EditorKeyDownMessageFilter());
 
 	if (GenioNames::Settings.show_projects == false)
 		fProjectsTabView->Hide();
@@ -271,23 +273,6 @@ GenioWindow::~GenioWindow()
 void
 GenioWindow::DispatchMessage(BMessage* message, BHandler* handler)
 {
-	//simple hack to move the 'SignatureHelp' list using the up/down arrows..
-	if (message->what == B_KEY_DOWN) {
-		int8 key = message->GetInt8("byte", 0);
-		if (key == B_UP_ARROW || key == B_DOWN_ARROW) {
-			Editor* editor = fTabManager->SelectedEditor();
-			if (editor && editor->IsSignatureHelpVisible()){
-				int32 len = be_app->CountWindows();
-				for (int32 i=0;i<len;i++)  {
-					BWindow* w = be_app->WindowAt (i);
-					if (strcmp(w->Title(), "calltip") == 0) {
-						editor->NextSignatureHelp(key == B_UP_ARROW ? 1 : 2);
-						return;
-					}
-				}
-			}
-	  }
-	}
 	//TODO: understand this part of code and move it to a better place.
 	if (handler == fConsoleIOView) {
 		if (message->what == B_KEY_DOWN) {

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -271,6 +271,23 @@ GenioWindow::~GenioWindow()
 void
 GenioWindow::DispatchMessage(BMessage* message, BHandler* handler)
 {
+	//simple hack to move the 'SignatureHelp' list using the up/down arrows..
+	if (message->what == B_KEY_DOWN) {
+		int8 key = message->GetInt8("byte", 0);
+		if (key == B_UP_ARROW || key == B_DOWN_ARROW) {
+			Editor* editor = fTabManager->SelectedEditor();
+			if (editor && editor->IsSignatureHelpVisible()){
+				int32 len = be_app->CountWindows();
+				for (int32 i=0;i<len;i++)  {
+					BWindow* w = be_app->WindowAt (i);
+					if (strcmp(w->Title(), "calltip") == 0) {
+						editor->NextSignatureHelp(key == B_UP_ARROW ? 1 : 2);
+						return;
+					}
+				}
+			}
+	  }
+	}
 	//TODO: understand this part of code and move it to a better place.
 	if (handler == fConsoleIOView) {
 		if (message->what == B_KEY_DOWN) {


### PR DESCRIPTION
This change allows the user to move from one signature help to another by using the arrow up and arrow down keys.
As it's not possible to override the scintillaview KeyDown method, this change adds a MessageFilter to call a 'BeforeKeyDown' method on the Editor (can be usefull for future changes).
The current BeforeKeyDown implementation just manages the arrow up/down keys in case the Signature Help is visible.